### PR TITLE
:wrench: Update config, fix & bump envsubst download

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 CONFIG_STATESYNC_ENABLE=true
-CONFIG_STATESYNC_RPC_SERVERS=https://canto-rpc.polkachu.com:443,https://rpc.canto.nodestake.top:443
+CONFIG_STATESYNC_RPC_SERVERS=https://canto-rpc.polkachu.com:443,https://canto-mainnet-rpc.autostake.com:443,https://rpc.canto.silentvalidator.com:443
+# https://polkachu.com/seeds/canto & https://autostake.com/networks/canto/#services
+CONFIG_P2P_SEEDS=ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:15556,ebc272824924ea1a27ea3183dd0b9ba713494f83@canto-mainnet-seed.autostake.com:27156

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 RUN git clone --depth 1 --branch v$VERSION https://github.com/Canto-Network/Canto.git Canto-$VERSION && \
     cd Canto-$VERSION && \
     make && \
-    wget https://github.com/a8m/envsubst/releases/download/v1.2.0/envsubst-`uname -s`-`uname -m` -O /tmp/envsubst && \
+    wget https://github.com/a8m/envsubst/releases/download/v1.4.2/envsubst-$(uname -s)-$(if [ "$(uname -m)" = "aarch64" ]; then echo "arm64"; else uname -m; fi) -O /tmp/envsubst && \
     cd /app
 
 FROM alpine:3
@@ -37,7 +37,9 @@ RUN install -m 0755 -o root -g root -t /usr/local/bin /tmp/cantod && \
     install -m 0755 -o root -g root -t /usr/local/bin /tmp/envsubst && \
     rm /tmp/envsubst
 
-COPY config/ /
+COPY config/docker-entrypoint.sh /
+COPY config/docker-entrypoint.d/ /docker-entrypoint.d/
+COPY config/root/ /root/
 WORKDIR /root
 
 STOPSIGNAL SIGINT

--- a/README.md
+++ b/README.md
@@ -6,14 +6,28 @@ Canto images for all versions.
 
 # Usage
 
-Pull and use the image directly:
+Prepare the `.env` file:
+
+```sh
+cp .env.example .env
+```
+
+Then pull and use the image directly:
 
 ```sh
 docker run --env-file .env gcr.io/dfpl-playground/canto
 ```
+
 Or a specific version:
+
 ```sh
-docker run --env-file .env gcr.io/dfpl-playground/canto:6.0.0
+docker run --env-file .env gcr.io/dfpl-playground/canto:7.0.0
+```
+
+Persisting chain data using volumes:
+
+```sh
+docker run --env-file .env --volume $(pwd)/data:/root/.cantod/data gcr.io/dfpl-playground/canto
 ```
 
 Or build from it:


### PR DESCRIPTION
- update `CONFIG_STATESYNC_RPC_SERVERS` & `CONFIG_P2P_SEEDS` examples
- fix envsubst 404 for ARM
- update COPY command to not include (yet to come) monitoring config
- update usage instructions