### PR TITLE
:wrench: Migrate to Artifact Repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
-PROJECT=dfpl-playground
-REGISTRY=gcr.io/$(PROJECT)
+PROJECT=ansybl
+REGISTRY_REGION=us-docker
+REGISTRY_HOSTNAME=$(REGISTRY_REGION).pkg.dev
+REGISTRY_REPOSITORY=public
+REGISTRY=$(REGISTRY_HOSTNAME)/$(PROJECT)/$(REGISTRY_REPOSITORY)
 IMAGE_NAME=canto
 DOCKER_IMAGE=$(REGISTRY)/$(IMAGE_NAME)
 VERSION=7.0.0
@@ -21,7 +24,7 @@ docker/build/versions:
 docker/build: docker/build/versions
 
 docker/login:
-	gcloud auth print-access-token | docker login -u oauth2accesstoken --password-stdin https://gcr.io
+	gcloud auth configure-docker us-docker.pkg.dev
 
 docker/push/version/%:
 	docker push $(DOCKER_IMAGE):$*

--- a/README.md
+++ b/README.md
@@ -15,25 +15,25 @@ cp .env.example .env
 Then pull and use the image directly:
 
 ```sh
-docker run --env-file .env gcr.io/dfpl-playground/canto
+docker run --env-file .env us-docker.pkg.dev/ansybl/public/canto
 ```
 
 Or a specific version:
 
 ```sh
-docker run --env-file .env gcr.io/dfpl-playground/canto:7.0.0
+docker run --env-file .env us-docker.pkg.dev/ansybl/public/canto:7.0.0
 ```
 
 Persisting chain data using volumes:
 
 ```sh
-docker run --env-file .env --volume $(pwd)/data:/root/.cantod/data gcr.io/dfpl-playground/canto
+docker run --env-file .env --volume $(pwd)/data:/root/.cantod/data us-docker.pkg.dev/ansybl/public/canto
 ```
 
 Or build from it:
 
 ```dockerfile
-FROM gcr.io/dfpl-playground/canto
+FROM us-docker.pkg.dev/ansybl/public/canto
 # any executable within /docker-entrypoint.d/ will get loaded
 COPY ./20-extra-init.sh /docker-entrypoint.d/
 RUN chmod u+x /docker-entrypoint.d/20-extra-init.sh


### PR DESCRIPTION
Google Container Registry is being deprecated.
Make the Artifact Repository public with:
```
gcloud --project ansybl \
artifacts repositories add-iam-policy-binding public \
--location=us --member=allUsers --role roles/artifactregistry.reader
```
Images can then be pulled with e.g.
```
docker pull us-docker.pkg.dev/ansybl/public/canto
```