### PR TITLE
:bug: Version 5.0.0 doesn't have a genesis file in Github

### DIFF
--- a/config/docker-entrypoint.d/10-cantod-init.sh
+++ b/config/docker-entrypoint.d/10-cantod-init.sh
@@ -4,7 +4,12 @@
 set -e
 
 CHAIN_ID=${CHAIN_ID:-canto_7700-1}
-GENESIS_URL=${GENESIS_URL:-https://raw.githubusercontent.com/Canto-Network/Canto/v${VERSION}/Networks/Mainnet/genesis.json}
+# versions that don't have a genesis file in GitHub are remapped here
+case "$VERSION" in
+    "5.0.0") REMAPPED_VERSION="5.0.1" ;;
+    *) REMAPPED_VERSION="$VERSION" ;;
+esac
+GENESIS_URL=${GENESIS_URL:-https://raw.githubusercontent.com/Canto-Network/Canto/v${REMAPPED_VERSION}/Networks/Mainnet/genesis.json}
 
 export_by_prefix() {
   prefix=$1

--- a/config/etc/grafana/provisioning/datasources/prometheus.yml
+++ b/config/etc/grafana/provisioning/datasources/prometheus.yml
@@ -3,6 +3,6 @@ datasources:
   - name: prometheus
     orgId: 1
     type: prometheus
-    url: http://prometheus:19090
+    url: http://prometheus:9090
     isDefault: true
     editable: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - .env
   prometheus:
     image: prom/prometheus:v2.48.0
+    restart: unless-stopped
     profiles:
       - optional
     ports:
@@ -27,6 +28,7 @@ services:
       - ./config/etc/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
   grafana:
     image: grafana/grafana:10.2.2
+    restart: unless-stopped
     profiles:
       - optional
     ports:


### PR DESCRIPTION
Remapped 5.0.0 to 5.0.1 as the download was leading to a 404.
Also fix prometheus port as consumed by the grafana container.