### PR TITLE
:arrow_up: Bump to v8

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-VERSION=7.0.1
+VERSION=8.0.0
 CONFIG_STATESYNC_ENABLE=true
 CONFIG_STATESYNC_RPC_SERVERS=https://canto-rpc.polkachu.com:443,https://canto-mainnet-rpc.autostake.com:443,https://rpc.canto.silentvalidator.com:443
 # https://polkachu.com/seeds/canto & https://autostake.com/networks/canto/#services

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-ARG VERSION=7.0.1
-FROM golang:1.20-alpine AS buildenv
+ARG VERSION=8.0.0
+ARG GO_VERSION=1.21
+FROM golang:${GO_VERSION}-alpine AS buildenv
 
 ARG VERSION
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker run --env-file .env us-docker.pkg.dev/ansybl/public/canto
 Or a specific version:
 
 ```sh
-docker run --env-file .env us-docker.pkg.dev/ansybl/public/canto:7.0.1
+docker run --env-file .env us-docker.pkg.dev/ansybl/public/canto:8.0.0
 ```
 
 Persisting chain data using volumes:


### PR DESCRIPTION
Adjust Dockerfile and Makefile to build Canto 8 with golang 1.21.
The error was:
```
1.701 go: errors parsing go.mod:
1.701 /app/Canto-8.0.0/go.mod:5: unknown directive: toolchain
1.707 mkdir -p /app/Canto-8.0.0/build/
1.707 go build -tags "netgo ledger" -ldflags '-X github.com/cosmos/cosmos-sdk/version.Name=canto -X github.com/cosmos/cosmos-sdk/version.AppName=cantod -X github.com/cosmos/cosmos-sdk/version.Version=8.0.0 -X github.com/cosmos/cosmos-sdk/version.Commit=12a18d7124a50b59cd44ec2ea7c00275165177d9 -X "github.com/cosmos/cosmos-sdk/version.BuildTags=netgo ledger," -X github.com/cometbft/cometbft/version.TMCoreSemVer= -w -s' -trimpath -o /app/Canto-8.0.0/build/ ./...
1.710 go: errors parsing go.mod:
1.710 /app/Canto-8.0.0/go.mod:5: unknown directive: toolchain
1.710 make: *** [Makefile:141: build] Error 1
```