### PR TITLE
:arrow_up: Bump to v8.1.3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-VERSION=8.1.2
+VERSION=8.1.3
 CONFIG_STATESYNC_ENABLE=true
 CONFIG_STATESYNC_RPC_SERVERS=https://canto-rpc.polkachu.com:443,https://canto-mainnet-rpc.autostake.com:443,https://rpc.canto.silentvalidator.com:443
 # https://polkachu.com/seeds/canto & https://autostake.com/networks/canto/#services

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=8.1.2
+ARG VERSION=8.1.3
 ARG GO_VERSION=1.21
 FROM golang:${GO_VERSION}-alpine AS buildenv
 

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ REGISTRY_REPOSITORY=public
 REGISTRY=$(REGISTRY_HOSTNAME)/$(PROJECT)/$(REGISTRY_REPOSITORY)
 IMAGE_NAME=canto
 DOCKER_IMAGE=$(REGISTRY)/$(IMAGE_NAME)
-VERSION=8.1.2
-VERSIONS=1.0.0 2.0.0 3.0.0 4.0.0 5.0.0 5.0.2 6.0.0 7.0.0 7.0.1 7.1.0 8.0.0 8.1.0 8.1.1 8.1.2
+VERSION=8.1.3
+VERSIONS=1.0.0 2.0.0 3.0.0 4.0.0 5.0.0 5.0.2 6.0.0 7.0.0 7.0.1 7.1.0 8.0.0 8.1.0 8.1.1 8.1.3
 IMAGE_TAG=$(VERSION)
 
 # Determine the Go version based on the Canto version
@@ -34,7 +34,7 @@ docker/build/versions:
 docker/build: docker/build/versions
 
 docker/login:
-	gcloud auth configure-docker $(REGISTRY_REGION).pkg.dev
+	gcloud auth configure-docker $(REGISTRY_HOSTNAME)
 
 docker/push/version/%:
 	docker push $(DOCKER_IMAGE):$*

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker run --env-file .env us-docker.pkg.dev/ansybl/public/canto
 Or a specific version:
 
 ```sh
-docker run --env-file .env us-docker.pkg.dev/ansybl/public/canto:8.1.2
+docker run --env-file .env us-docker.pkg.dev/ansybl/public/canto:8.1.3
 ```
 
 Persisting chain data using volumes:


### PR DESCRIPTION
Fixes the `eth_getTransactionReceipt` EVM RPC call for blocks between 10848200 produced in v8.0.0 and 10849448 produced in v8.1.1, for instance:
```
curl http://localhost:8545 \
  --header 'Content-Type: application/json' \
  --data '{
  "jsonrpc": "2.0",
  "method": "eth_getTransactionReceipt",
  "params": [
    "0x17a1cacf3e10d3021157b3b1bb37c20ff5346c198c26b2706b140e15844f8b2c"
  ],
  "id": 1
}'
```
The error was:
```
{
  "jsonrpc":"2.0",
  "id": 1,
  "error": {
    "code": -32000,
    "message": "invalid chain id for signer"
  }
}
```