### PR TITLE
:sparkles: Expose the RPC CORS allowed origins setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 VERSION=8.1.3
 CONFIG_STATESYNC_ENABLE=true
-CONFIG_STATESYNC_RPC_SERVERS=https://canto-rpc.polkachu.com:443,https://canto-mainnet-rpc.autostake.com:443,https://rpc.canto.silentvalidator.com:443
-# https://polkachu.com/seeds/canto & https://autostake.com/networks/canto/#services
-CONFIG_P2P_SEEDS=ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:15556,ebc272824924ea1a27ea3183dd0b9ba713494f83@canto-mainnet-seed.autostake.com:27156
+CONFIG_STATESYNC_RPC_SERVERS=https://canto-rpc.polkachu.com:443,https://canto-rpc.polkachu.com:443
+# https://polkachu.com/seeds/canto
+CONFIG_P2P_SEEDS=ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:15556

--- a/config/root/.cantod/config/config.template.toml
+++ b/config/root/.cantod/config/config.template.toml
@@ -93,7 +93,7 @@ laddr = "${CONFIG_RPC_LADDR:-tcp://0.0.0.0}:${RPC_PORT:-26657}"
 # A list of origins a cross-domain request can be executed from
 # Default value '[]' disables cors support
 # Use '["*"]' to allow any origin
-cors_allowed_origins = []
+cors_allowed_origins = ${CONFIG_RPC_CORS_ALLOWED_ORIGINS:-[]}
 
 # A list of methods the client is allowed to use with cross-domain requests
 cors_allowed_methods = ["HEAD", "GET", "POST", ]


### PR DESCRIPTION
Via `CONFIG_RPC_CORS_ALLOWED_ORIGINS`, defaults to `[]`. Also update the `.env.example` with up to date state sync RPC servers.