### PR TITLE
:technologist: Simulate a v2.0.2 tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ ARG VERSION=8.1.3
 ARG GO_VERSION=1.21
 FROM golang:${GO_VERSION}-alpine AS buildenv
 
+ARG BRANCH
 ARG VERSION
 
 # Set up dependencies
@@ -16,9 +17,17 @@ RUN apk add --update --no-cache \
 # Set working directory for the build
 WORKDIR /app
 
-RUN git clone --depth 1 --branch v$VERSION https://github.com/Canto-Network/Canto.git Canto-$VERSION && \
-    cd Canto-$VERSION && \
-    make && \
+# simulate a v2.0.2 tag using the thomas/archive-patch branch, refs:
+# https://github.com/Canto-Network/Canto/issues/97
+RUN if [ -n "$BRANCH" ]; then \
+        git clone --branch "$BRANCH" https://github.com/Canto-Network/Canto.git Canto-$VERSION && \
+        cd Canto-$VERSION && \
+        make; \
+    else \
+        git clone --depth 1 --branch v$VERSION https://github.com/Canto-Network/Canto.git Canto-$VERSION && \
+        cd Canto-$VERSION && \
+        make; \
+    fi && \
     wget https://github.com/a8m/envsubst/releases/download/v1.4.2/envsubst-$(uname -s)-$(if [ "$(uname -m)" = "aarch64" ]; then echo "arm64"; else uname -m; fi) -O /tmp/envsubst && \
     cd /app
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ REGISTRY=$(REGISTRY_HOSTNAME)/$(PROJECT)/$(REGISTRY_REPOSITORY)
 IMAGE_NAME=canto
 DOCKER_IMAGE=$(REGISTRY)/$(IMAGE_NAME)
 VERSION=8.1.3
-VERSIONS=1.0.0 2.0.0 3.0.0 4.0.0 5.0.0 5.0.2 6.0.0 7.0.0 7.0.1 7.1.0 8.0.0 8.1.0 8.1.1 8.1.3
+VERSIONS=1.0.0 2.0.0 2.0.2 3.0.0 4.0.0 5.0.0 5.0.2 6.0.0 7.0.0 7.0.1 7.1.0 8.0.0 8.1.0 8.1.1 8.1.3
 IMAGE_TAG=$(VERSION)
 
 # Determine the Go version based on the Canto version
@@ -24,7 +24,13 @@ docker/pull:
 
 docker/build/version/%:
 	$(eval GO_VERSION := $(shell $(call get_go_version,$*)))
-	docker build --tag=$(DOCKER_IMAGE):$* --build-arg VERSION=$* --build-arg GO_VERSION=$(GO_VERSION) .
+	# simulate a v2.0.2 tag using the thomas/archive-patch branch, refs:
+	# https://github.com/Canto-Network/Canto/issues/97
+	if [ "$*" = "2.0.2" ]; then \
+	    docker build --tag=$(DOCKER_IMAGE):$* --build-arg VERSION=$* --build-arg BRANCH=thomas/archive-patch --build-arg GO_VERSION=$(GO_VERSION) .; \
+	else \
+	    docker build --tag=$(DOCKER_IMAGE):$* --build-arg VERSION=$* --build-arg GO_VERSION=$(GO_VERSION) .; \
+	fi
 
 docker/build/versions:
 	for version in $(VERSIONS) ; do \

--- a/config/docker-entrypoint.d/10-cantod-init.sh
+++ b/config/docker-entrypoint.d/10-cantod-init.sh
@@ -6,6 +6,7 @@ set -e
 CHAIN_ID=${CHAIN_ID:-canto_7700-1}
 # versions that don't have a genesis file in GitHub are remapped here
 case "$VERSION" in
+    "2.0.2") REMAPPED_VERSION="2.0.0" ;;
     "5.0.0") REMAPPED_VERSION="5.0.1" ;;
     *) REMAPPED_VERSION="$VERSION" ;;
 esac


### PR DESCRIPTION
The v2.0.2 tag doesn't actually exist, we remapped the `thomas/archive-patch` branch as if it was tagged v2.0.2, refs:
https://github.com/Canto-Network/Canto/issues/97

This way it can be built as:
```
make docker/build/version/2.0.2
```